### PR TITLE
Load ModelCmp command as lazy

### DIFF
--- a/lua/model_cmp/commands.lua
+++ b/lua/model_cmp/commands.lua
@@ -77,15 +77,9 @@ local function virtualtext_create_autocmds(group)
     })
 end
 
-local function create_usercmds()
-    vim.api.nvim_create_user_command("ModelCmp", function(args)
-        args = args.fargs
-        if #args == 0 or args == nil then
-            return
-        end
-        local virtualtext = require("model_cmp.virtualtext")
-
+function M.load_actions(args)
         local actions = {}
+        local virtualtext = require("model_cmp.virtualtext")
         actions.virtualtext = {
             enable = function()
                 virtualtext.action.enable_auto_trigger()
@@ -113,25 +107,9 @@ local function create_usercmds()
             end,
         }
         actions[args[1]][args[2]]()
-    end, {
-        nargs = "+",
-        complete = function(_, cmdline, _)
-            cmdline = cmdline or ""
+end
 
-            if cmdline:find("virtualtext") then
-                return {
-                    "enable",
-                    "disable",
-                    "toggle",
-                }
-            end
-            if cmdline:find("capture") then
-                return { "first", "all" }
-            end
-            return { "virtualtext", "capture", "server" }
-        end,
-    })
-
+local function create_usercmds()
     vim.api.nvim_create_user_command("ModelCmpStart", function(args)
         args = args.fargs
         local servers = {

--- a/plugin/model_cmp.lua
+++ b/plugin/model_cmp.lua
@@ -1,1 +1,30 @@
-require("model_cmp.init")
+if vim.g.loaded_model_cmp == 1 then
+    return
+end
+vim.g.loaded_model_cmp = 1
+
+vim.api.nvim_create_user_command("ModelCmp", function(args)
+        args = args.fargs
+        if #args == 0 or args == nil then
+            -- launch the default settings
+            return
+        end
+        require("model_cmp.commands").load_actions(args)
+end, {
+    nargs = "*",
+        complete = function(_, cmdline, _)
+            cmdline = cmdline or ""
+
+            if cmdline:find("virtualtext") then
+                return {
+                    "enable",
+                    "disable",
+                    "toggle",
+                }
+            end
+            if cmdline:find("capture") then
+                return { "first", "all" }
+            end
+            return { "virtualtext", "capture", "server" }
+        end,
+})


### PR DESCRIPTION
moved the nvim_create_user_command function to create "ModelCmp" to `plugin/model_cmp.lua` to load it with config

```lua
return {
  "PyDevC/model_cmp.nvim",
  lazy = true,
  cmd = {"ModelCmp"},
  config = function()
    require("model_cmp").setup({ })
    vim.keymap.set("i", "<C-i>", "<cmd>ModelCmp capture first<CR>")
  end,
}

```