### PR TITLE
fix: correct max_token to max_tokens in llama.lua (issue #47)

### DIFF
--- a/lua/model_cmp/modelapi/llama.lua
+++ b/lua/model_cmp/modelapi/llama.lua
@@ -40,7 +40,7 @@ function M.generate_request(prompt)
             n_predict = 128,
             temperature = 0.1,
             stop = { "</s>" },
-            max_token = 50,
+            max_tokens = 50,
         }),
     }
     return request


### PR DESCRIPTION
## Summary
Correct typo `max_token` → `max_tokens` in llama.lua line 43.

## Changes
- `lua/model_cmp/modelapi/llama.lua:43`: `max_token = 50` → `max_tokens = 50`

## Verification
- Single commit ✅
- One-line fix ✅
- Addresses issue #47